### PR TITLE
slack at the bottom + keynotes at the top

### DIFF
--- a/_includes/contact.html
+++ b/_includes/contact.html
@@ -6,27 +6,31 @@
                 <hr class="primary">
                 <p>Contact us for information or with your ideas.</p>
             </div>
-            
+
             <div class="col-lg-2 col-lg-offset-2 text-center">
+                <a href="mailto:{{ site.email }}">
+                    <i class="fa fa-envelope-o fa-3x wow bounceIn" data-wow-delay=".1s"></i>
+                    <p>Mail us</p>
+                </a>
+            </div>
+
+            <div class="col-lg-2 col-lg-offset-1 text-center"><a href="https://brainhack-slack-invite.herokuapp.com/">Join us on Slack</a>
+            #bhg18-rennes
+            </div>
+            
+            <div class="col-lg-2 col-lg-offset-1 text-center">
                 <a href="https://twitter.com/brainhackorg">
                     <i class="fa fa-twitter fa-3x wow bounceIn" data-wow-delay=".1s"></i>
                     <p>brainhackorg</p>
                 </a>
             </div>
             
-            <div class="col-lg-2 col-lg-offset-1 text-center">
-                <a href="mailto:{{ site.email }}">
-                    <i class="fa fa-envelope-o fa-3x wow bounceIn" data-wow-delay=".1s"></i>
-                    <p>Mail us</p>
-                </a>
-            </div>
-            
-            <div class="col-lg-2 col-lg-offset-1 text-center">
+<!--             <div class="col-lg-2 col-lg-offset-1 text-center">
                 <a href="https://github.com/{{ site.github_username }}">
                     <i class="fa fa-github fa-3x wow bounceIn" data-wow-delay=".1s"></i>
                     <p>{{ site.github_username }}</p>
                 </a>
-            </div>            
+            </div>        -->     
         </div>
     </div>
 </section>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,5 +1,6 @@
 <header>
     <div class="header-content">
+        <br/><br/><br/><br/>
         <div class="header-content-inner">
             <h1>Brainhack Rennes</h1>
             <h2><b>Open science hackathon</b></h2>
@@ -7,8 +8,29 @@
             <strike><h4>May 2-6</h4></strike>
             <h3>An early event of <a href="http://www.brainhack.org/global2018/">BrainHack Global</a></h3>
             <hr/>
-            <h3><a href="https://brainhack-slack-invite.herokuapp.com/">Join us on Slack</a></h3>
-            <h4>#bhg18-rennes</h4>
+            <div class="row">
+                <h2>Keynote speakers</h2>
+              <div class="col-lg-10 col-lg-offset-1 col-md-10 col-md-offset-1">
+                <h4>Machine learning: applications, methods and challenges
+                <!-- (<a href="slides/my_slides.pdf">Slides</a>)<br> -->
+                <br/>
+                <strong>Elisa Fromont</strong>
+                </h4>
+                <h4>Reproducible research — is it worth the effort, and how to ease it?
+                <br>
+                <strong>Rémi Gribonval</strong>
+                </h4>
+                <h4>EEG source localisations in epilepsy
+                <br>
+                <strong>Isabelle Merlet</strong>
+                </h4>
+                <h4>Towards a collective neuroscience
+                <!-- (<a href="slides/my_slides.pdf">Slides</a>)<br> -->
+                <br/>
+                <strong>Roberto Toro</strong>
+                </h4>
+              </div>
+            </div>
             <hr/>
             <a href="http://gipco-adns.com/site/6635/inscription+registration-brainhack+rennes+2018-" class="btn btn-primary btn-xl page-scroll">Registration</a><br><br>
             <a href="http://www.brainhack.org/global2018/projects.html" class="btn btn-primary btn-xl page-scroll">Submit a Project!</a>


### PR DESCRIPTION
As discussed with @ocommowi and @jcoloigner, this pull request:
 - moves down the slack info to the contact pane and 
 - adds info abou the keynotes at the top.

I have to say the results, does not look super great... I do think it's important to have that info at the top but please feel free to update to make it look nicer :)
